### PR TITLE
feat(youtube): add backend personal keys and improve remote sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,5 +11,10 @@ DB_NAME=kantatube
 YOUTUBE_API_KEYS={"primary":"replace-with-key","backup":"replace-with-key"}
 YOUTUBE_DEFAULT_API_KEY_ALIAS=primary
 
+# Personal keys are stored only in backend memory, keyed by visitor ID. They
+# remain until explicitly removed or until the backend process restarts.
+YOUTUBE_PERSONAL_KEYS_ENABLED=true
+YOUTUBE_PERSONAL_KEY_MAX_SESSIONS=200
+
 # Optional fallback for deployments that use only one key.
 YOUTUBE_API_KEY=

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,9 +2,11 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ConfigService } from '@nestjs/config';
 import { urlencoded, json } from 'express'; // MUST IMPORT THIS
+import { NestExpressApplication } from '@nestjs/platform-express';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+  app.set('trust proxy', 1);
   const configService = app.get(ConfigService);
   // Get environment variables
   const PORT = configService.get<number>('PORT') || 3000;
@@ -15,6 +17,7 @@ async function bootstrap() {
     'http://192.168.254.103',
     `http://192.168.1.18`,
     `http://192.168.1.4`,
+    'http://192.168.254.103:4200',
     'https://kantatube.vercel.app',
     'https://kantatube-git-staging-elvins-projects-39449bae.vercel.app',
     'https://kantatube-git-development-elvins-projects-39449bae.vercel.app'
@@ -22,7 +25,7 @@ async function bootstrap() {
   app.enableCors({
     origin: ALLOWED_ORIGINS,
     methods: 'GET,POST,PUT,DELETE,OPTIONS',
-    allowedHeaders: 'Content-Type, Authorization',
+    allowedHeaders: 'Content-Type, Authorization, X-KantaTube-Visitor-ID',
     credentials: true,
   });
 

--- a/src/modules/youtube/youtube-personal-key.service.spec.ts
+++ b/src/modules/youtube/youtube-personal-key.service.spec.ts
@@ -1,0 +1,72 @@
+import { ConfigService } from '@nestjs/config';
+import { YoutubePersonalKeyService } from './youtube-personal-key.service';
+
+describe('YoutubePersonalKeyService', () => {
+  const visitorId = '123e4567-e89b-42d3-a456-426614174000';
+  const otherVisitorId = '123e4567-e89b-42d3-a456-426614174001';
+  const apiKey = `AIza${'a'.repeat(35)}`;
+
+  function createService(
+    values: Record<string, string> = {},
+  ): YoutubePersonalKeyService {
+    const configService = {
+      get: jest.fn((name: string) => values[name]),
+    } as unknown as ConfigService;
+    return new YoutubePersonalKeyService(configService);
+  }
+
+  it('stores a key by visitor ID without returning the key value', () => {
+    const service = createService();
+
+    const response = service.register(visitorId, apiKey);
+
+    expect(response).toEqual({
+      available: true,
+      alias: YoutubePersonalKeyService.alias,
+    });
+    expect(JSON.stringify(response)).not.toContain(apiKey);
+    expect(service.resolve(visitorId)).toBe(apiKey);
+  });
+
+  it('does not allow another visitor ID to resolve the key', () => {
+    const service = createService();
+    service.register(visitorId, apiKey);
+
+    expect(service.getStatus(otherVisitorId).available).toBe(false);
+    expect(() => service.resolve(otherVisitorId)).toThrow();
+  });
+
+  it('replaces and removes the key only under the matching visitor ID', () => {
+    const service = createService();
+    const replacementKey = `AIza${'b'.repeat(35)}`;
+    service.register(visitorId, apiKey);
+    service.register(visitorId, replacementKey);
+
+    expect(service.resolve(visitorId)).toBe(replacementKey);
+    expect(service.remove(otherVisitorId)).toEqual({ removed: false });
+    expect(service.remove(visitorId)).toEqual({ removed: true });
+    expect(service.getStatus(visitorId).available).toBe(false);
+  });
+
+  it('rejects invalid visitor IDs and invalid API-key formats', () => {
+    const service = createService();
+
+    expect(() => service.register('legacy123', apiKey)).toThrow();
+    expect(() => service.register(visitorId, 'not-a-key')).toThrow();
+  });
+
+  it('rejects new sessions at capacity without evicting existing keys', () => {
+    const service = createService({ YOUTUBE_PERSONAL_KEY_MAX_SESSIONS: '1' });
+    service.register(visitorId, apiKey);
+
+    expect(() => service.register(otherVisitorId, apiKey)).toThrow();
+    expect(service.resolve(visitorId)).toBe(apiKey);
+  });
+
+  it('can be disabled with configuration', () => {
+    const service = createService({ YOUTUBE_PERSONAL_KEYS_ENABLED: 'false' });
+
+    expect(() => service.register(visitorId, apiKey)).toThrow();
+    expect(service.has(visitorId)).toBe(false);
+  });
+});

--- a/src/modules/youtube/youtube-personal-key.service.ts
+++ b/src/modules/youtube/youtube-personal-key.service.ts
@@ -1,0 +1,136 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  YoutubePersonalKeyDeleteResponse,
+  YoutubePersonalKeyStatusResponse,
+} from './youtube.types';
+
+@Injectable()
+export class YoutubePersonalKeyService {
+  static readonly alias = 'personal_session';
+
+  private readonly keysByVisitorId = new Map<string, string>();
+  private readonly maxSessions: number;
+
+  constructor(private readonly configService: ConfigService) {
+    const configuredMaximum = Number(
+      this.configService.get<string>('YOUTUBE_PERSONAL_KEY_MAX_SESSIONS'),
+    );
+    this.maxSessions =
+      Number.isInteger(configuredMaximum) && configuredMaximum > 0
+        ? configuredMaximum
+        : 200;
+  }
+
+  register(visitorId: string, apiKey: string): YoutubePersonalKeyStatusResponse {
+    this.ensureEnabled();
+    const normalizedVisitorId = this.validateVisitorId(visitorId);
+    const normalizedApiKey = this.validateApiKey(apiKey);
+
+    if (
+      !this.keysByVisitorId.has(normalizedVisitorId) &&
+      this.keysByVisitorId.size >= this.maxSessions
+    ) {
+      throw new ServiceUnavailableException({
+        code: 'personal_key_capacity_reached',
+        message:
+          'Personal key registration is temporarily full. Remove an existing personal key or try again later.',
+      });
+    }
+
+    this.keysByVisitorId.set(normalizedVisitorId, normalizedApiKey);
+    return this.getStatus(normalizedVisitorId);
+  }
+
+  getStatus(visitorId: string): YoutubePersonalKeyStatusResponse {
+    this.ensureEnabled();
+    const normalizedVisitorId = this.validateVisitorId(visitorId);
+    return {
+      available: this.keysByVisitorId.has(normalizedVisitorId),
+      alias: YoutubePersonalKeyService.alias,
+    };
+  }
+
+  remove(visitorId: string): YoutubePersonalKeyDeleteResponse {
+    this.ensureEnabled();
+    const normalizedVisitorId = this.validateVisitorId(visitorId);
+    return { removed: this.keysByVisitorId.delete(normalizedVisitorId) };
+  }
+
+  resolve(visitorId: string): string {
+    this.ensureEnabled();
+    const normalizedVisitorId = this.validateVisitorId(visitorId);
+    const apiKey = this.keysByVisitorId.get(normalizedVisitorId);
+
+    if (!apiKey) {
+      throw new NotFoundException({
+        code: 'personal_key_not_registered',
+        message:
+          'No personal YouTube API key is registered for this visitor session.',
+      });
+    }
+
+    return apiKey;
+  }
+
+  has(visitorId?: string): boolean {
+    if (!visitorId || !this.isEnabled() || !this.isValidVisitorId(visitorId)) {
+      return false;
+    }
+
+    return this.keysByVisitorId.has(visitorId.trim());
+  }
+
+  private validateVisitorId(visitorId: string): string {
+    const normalizedVisitorId = (visitorId ?? '').trim();
+    if (!this.isValidVisitorId(normalizedVisitorId)) {
+      throw new BadRequestException({
+        code: 'invalid_visitor_id',
+        message: 'A valid KantaTube visitor ID is required.',
+      });
+    }
+
+    return normalizedVisitorId;
+  }
+
+  private isValidVisitorId(visitorId: string): boolean {
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      visitorId,
+    );
+  }
+
+  private validateApiKey(apiKey: string): string {
+    const normalizedApiKey = (apiKey ?? '').trim();
+    if (!/^AIza[0-9A-Za-z_-]{30,50}$/.test(normalizedApiKey)) {
+      throw new BadRequestException({
+        code: 'invalid_personal_key_format',
+        message: 'Please enter a valid YouTube API key.',
+      });
+    }
+
+    return normalizedApiKey;
+  }
+
+  private ensureEnabled(): void {
+    if (!this.isEnabled()) {
+      throw new ServiceUnavailableException({
+        code: 'personal_keys_disabled',
+        message: 'Personal YouTube API keys are currently disabled.',
+      });
+    }
+  }
+
+  private isEnabled(): boolean {
+    return (
+      this.configService
+        .get<string>('YOUTUBE_PERSONAL_KEYS_ENABLED')
+        ?.trim()
+        .toLowerCase() !== 'false'
+    );
+  }
+}

--- a/src/modules/youtube/youtube-rate-limiter.service.spec.ts
+++ b/src/modules/youtube/youtube-rate-limiter.service.spec.ts
@@ -1,0 +1,22 @@
+import { YoutubeRateLimiterService } from './youtube-rate-limiter.service';
+
+describe('YoutubeRateLimiterService', () => {
+  it('limits repeated personal-key registrations', () => {
+    const service = new YoutubeRateLimiterService();
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      service.checkRegistration('client');
+    }
+
+    expect(() => service.checkRegistration('client')).toThrow();
+    expect(() => service.checkRegistration('other-client')).not.toThrow();
+  });
+
+  it('limits repeated searches independently from registrations', () => {
+    const service = new YoutubeRateLimiterService();
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      service.checkSearch('client');
+    }
+
+    expect(() => service.checkSearch('client')).toThrow();
+  });
+});

--- a/src/modules/youtube/youtube-rate-limiter.service.ts
+++ b/src/modules/youtube/youtube-rate-limiter.service.ts
@@ -1,0 +1,63 @@
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+
+interface RateLimitBucket {
+  timestamps: number[];
+}
+
+@Injectable()
+export class YoutubeRateLimiterService {
+  private readonly buckets = new Map<string, RateLimitBucket>();
+  private readonly maximumBuckets = 5000;
+
+  checkSearch(clientId: string): void {
+    this.check(`search:${clientId}`, 20, 60_000, 'youtube_search_rate_limited');
+  }
+
+  checkRegistration(clientId: string): void {
+    this.check(
+      `personal-key:${clientId}`,
+      5,
+      15 * 60_000,
+      'personal_key_registration_limited',
+    );
+  }
+
+  private check(
+    bucketKey: string,
+    limit: number,
+    windowMs: number,
+    code: string,
+  ): void {
+    const now = Date.now();
+    const cutoff = now - windowMs;
+    const bucket = this.buckets.get(bucketKey) ?? { timestamps: [] };
+    bucket.timestamps = bucket.timestamps.filter(
+      (timestamp) => timestamp > cutoff,
+    );
+
+    if (bucket.timestamps.length >= limit) {
+      throw new HttpException(
+        {
+          code,
+          message: 'Too many YouTube requests. Please wait and try again.',
+        },
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
+    bucket.timestamps.push(now);
+    this.buckets.set(bucketKey, bucket);
+    this.trimBuckets();
+  }
+
+  private trimBuckets(): void {
+    if (this.buckets.size <= this.maximumBuckets) {
+      return;
+    }
+
+    const oldestKey = this.buckets.keys().next().value as string | undefined;
+    if (oldestKey) {
+      this.buckets.delete(oldestKey);
+    }
+  }
+}

--- a/src/modules/youtube/youtube.controller.ts
+++ b/src/modules/youtube/youtube.controller.ts
@@ -1,24 +1,82 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Headers,
+  Post,
+  Query,
+  Req,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { YoutubePersonalKeyService } from './youtube-personal-key.service';
+import { YoutubeRateLimiterService } from './youtube-rate-limiter.service';
 import { YoutubeService } from './youtube.service';
 import {
   YoutubeKeyAliasesResponse,
+  YoutubePersonalKeyDeleteResponse,
+  YoutubePersonalKeyRequest,
+  YoutubePersonalKeyStatusResponse,
   YoutubeSearchResponse,
 } from './youtube.types';
 
 @Controller('youtube')
 export class YoutubeController {
-  constructor(private readonly youtubeService: YoutubeService) {}
+  constructor(
+    private readonly youtubeService: YoutubeService,
+    private readonly personalKeyService: YoutubePersonalKeyService,
+    private readonly rateLimiterService: YoutubeRateLimiterService,
+  ) {}
 
   @Get('key-aliases')
-  getKeyAliases(): YoutubeKeyAliasesResponse {
-    return this.youtubeService.getKeyAliases();
+  getKeyAliases(
+    @Headers('x-kantatube-visitor-id') visitorId?: string,
+  ): YoutubeKeyAliasesResponse {
+    return this.youtubeService.getKeyAliases(visitorId);
+  }
+
+  @Post('personal-keys')
+  registerPersonalKey(
+    @Headers('x-kantatube-visitor-id') visitorId: string,
+    @Body() request: YoutubePersonalKeyRequest,
+    @Req() httpRequest: Request,
+  ): YoutubePersonalKeyStatusResponse {
+    this.rateLimiterService.checkRegistration(
+      this.getClientId(httpRequest, visitorId),
+    );
+    return this.personalKeyService.register(visitorId, request?.apiKey);
+  }
+
+  @Get('personal-keys/status')
+  getPersonalKeyStatus(
+    @Headers('x-kantatube-visitor-id') visitorId: string,
+  ): YoutubePersonalKeyStatusResponse {
+    return this.personalKeyService.getStatus(visitorId);
+  }
+
+  @Delete('personal-keys')
+  removePersonalKey(
+    @Headers('x-kantatube-visitor-id') visitorId: string,
+  ): YoutubePersonalKeyDeleteResponse {
+    return this.personalKeyService.remove(visitorId);
   }
 
   @Get('search')
   search(
     @Query('q') query: string,
     @Query('keyAlias') keyAlias?: string,
+    @Headers('x-kantatube-visitor-id') visitorId?: string,
+    @Req() httpRequest?: Request,
   ): Promise<YoutubeSearchResponse> {
-    return this.youtubeService.search(query, keyAlias);
+    this.rateLimiterService.checkSearch(
+      this.getClientId(httpRequest, visitorId),
+    );
+    return this.youtubeService.search(query, keyAlias, visitorId);
+  }
+
+  private getClientId(request?: Request, visitorId?: string): string {
+    return `${request?.ip || 'unknown'}:${
+      visitorId?.trim() || 'no-visitor'
+    }`;
   }
 }

--- a/src/modules/youtube/youtube.module.ts
+++ b/src/modules/youtube/youtube.module.ts
@@ -1,9 +1,15 @@
 import { Module } from '@nestjs/common';
 import { YoutubeController } from './youtube.controller';
+import { YoutubePersonalKeyService } from './youtube-personal-key.service';
+import { YoutubeRateLimiterService } from './youtube-rate-limiter.service';
 import { YoutubeService } from './youtube.service';
 
 @Module({
   controllers: [YoutubeController],
-  providers: [YoutubeService],
+  providers: [
+    YoutubeService,
+    YoutubePersonalKeyService,
+    YoutubeRateLimiterService,
+  ],
 })
 export class YoutubeModule {}

--- a/src/modules/youtube/youtube.service.spec.ts
+++ b/src/modules/youtube/youtube.service.spec.ts
@@ -1,11 +1,13 @@
 import { ServiceUnavailableException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { YoutubePersonalKeyService } from './youtube-personal-key.service';
 import { YoutubeService } from './youtube.service';
 
 describe('YoutubeService', () => {
   const apiKey = 'server-only-test-key';
   const backupApiKey = 'server-only-backup-test-key';
   let service: YoutubeService;
+  let personalKeyService: YoutubePersonalKeyService;
   let fetchMock: jest.SpiedFunction<typeof fetch>;
 
   beforeEach(() => {
@@ -19,7 +21,8 @@ describe('YoutubeService', () => {
     const configService = {
       get: jest.fn((name: string) => configValues[name]),
     } as unknown as ConfigService;
-    service = new YoutubeService(configService);
+    personalKeyService = new YoutubePersonalKeyService(configService);
+    service = new YoutubeService(configService, personalKeyService);
     fetchMock = jest.spyOn(global, 'fetch');
   });
 
@@ -54,7 +57,9 @@ describe('YoutubeService', () => {
     const parsedUrl = new URL(requestUrl);
     expect(parsedUrl.searchParams.get('q')).toBe('test song Karaoke');
     expect(parsedUrl.searchParams.get('key')).toBe(apiKey);
-    expect(parsedUrl.searchParams.get('maxResults')).toBe('50');
+    expect(parsedUrl.searchParams.get('maxResults')).toBe('20');
+    expect(parsedUrl.searchParams.get('videoEmbeddable')).toBe('true');
+    expect(parsedUrl.searchParams.get('videoSyndicated')).toBe('true');
   });
 
   it('returns aliases without returning API key values', () => {
@@ -78,6 +83,42 @@ describe('YoutubeService', () => {
 
     const requestUrl = String(fetchMock.mock.calls[0][0]);
     expect(new URL(requestUrl).searchParams.get('key')).toBe(backupApiKey);
+  });
+
+  it('uses a personal key only for the exact matching visitor ID', async () => {
+    const visitorId = '123e4567-e89b-42d3-a456-426614174000';
+    const otherVisitorId = '123e4567-e89b-42d3-a456-426614174001';
+    const personalKey = `AIza${'a'.repeat(35)}`;
+    personalKeyService.register(visitorId, personalKey);
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ items: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    expect(service.getKeyAliases(visitorId).aliases).toContain(
+      YoutubePersonalKeyService.alias,
+    );
+    expect(service.getKeyAliases(otherVisitorId).aliases).not.toContain(
+      YoutubePersonalKeyService.alias,
+    );
+
+    await service.search(
+      'personal test',
+      YoutubePersonalKeyService.alias,
+      visitorId,
+    );
+    const requestUrl = String(fetchMock.mock.calls[0][0]);
+    expect(new URL(requestUrl).searchParams.get('key')).toBe(personalKey);
+
+    await expect(
+      service.search(
+        'wrong visitor',
+        YoutubePersonalKeyService.alias,
+        otherVisitorId,
+      ),
+    ).rejects.toMatchObject({ status: 404 });
   });
 
   it('rejects an alias that is not configured', async () => {
@@ -190,7 +231,8 @@ describe('YoutubeService', () => {
     const configService = {
       get: jest.fn().mockReturnValue(undefined),
     } as unknown as ConfigService;
-    service = new YoutubeService(configService);
+    personalKeyService = new YoutubePersonalKeyService(configService);
+    service = new YoutubeService(configService, personalKeyService);
 
     await expect(service.search('test')).rejects.toBeInstanceOf(
       ServiceUnavailableException,

--- a/src/modules/youtube/youtube.service.ts
+++ b/src/modules/youtube/youtube.service.ts
@@ -15,6 +15,7 @@ import {
   YoutubeSearchItem,
   YoutubeSearchResponse,
 } from './youtube.types';
+import { YoutubePersonalKeyService } from './youtube-personal-key.service';
 
 @Injectable()
 export class YoutubeService {
@@ -23,9 +24,12 @@ export class YoutubeService {
     'https://www.googleapis.com/youtube/v3/search';
   private readonly requestTimeoutMs = 10000;
 
-  constructor(private readonly configService: ConfigService) {}
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly personalKeyService: YoutubePersonalKeyService,
+  ) {}
 
-  getKeyAliases(): YoutubeKeyAliasesResponse {
+  getKeyAliases(visitorId?: string): YoutubeKeyAliasesResponse {
     const configuredKeys = this.getConfiguredApiKeys();
     const aliases = Object.keys(configuredKeys);
 
@@ -38,11 +42,17 @@ export class YoutubeService {
           ? configuredDefault
           : aliases[0];
 
-      return { aliases, defaultAlias };
+      return {
+        aliases: this.withPersonalAlias(aliases, visitorId),
+        defaultAlias,
+      };
     }
 
     if (this.configService.get<string>('YOUTUBE_API_KEY')?.trim()) {
-      return { aliases: ['default'], defaultAlias: 'default' };
+      return {
+        aliases: this.withPersonalAlias(['default'], visitorId),
+        defaultAlias: 'default',
+      };
     }
 
     this.throwMissingKeyConfiguration();
@@ -51,9 +61,10 @@ export class YoutubeService {
   async search(
     searchQuery: string,
     requestedKeyAlias?: string,
+    visitorId?: string,
   ): Promise<YoutubeSearchResponse> {
     const normalizedQuery = this.normalizeQuery(searchQuery);
-    const apiKey = this.resolveApiKey(requestedKeyAlias);
+    const apiKey = this.resolveApiKey(requestedKeyAlias, visitorId);
 
     const effectiveQuery = normalizedQuery.toLowerCase().includes('karaoke')
       ? normalizedQuery
@@ -66,6 +77,7 @@ export class YoutubeService {
       maxResults: '20',
       type: 'video',
       videoEmbeddable: 'true',
+      videoSyndicated: 'true',
       key: apiKey,
     });
     const controller = new AbortController();
@@ -141,7 +153,14 @@ export class YoutubeService {
     return normalized;
   }
 
-  private resolveApiKey(requestedAlias?: string): string {
+  private resolveApiKey(
+    requestedAlias?: string,
+    visitorId?: string,
+  ): string {
+    if (requestedAlias?.trim() === YoutubePersonalKeyService.alias) {
+      return this.personalKeyService.resolve(visitorId ?? '');
+    }
+
     const configuredKeys = this.getConfiguredApiKeys();
     const aliases = Object.keys(configuredKeys);
 
@@ -177,6 +196,15 @@ export class YoutubeService {
     }
 
     this.throwMissingKeyConfiguration();
+  }
+
+  private withPersonalAlias(
+    aliases: string[],
+    visitorId?: string,
+  ): string[] {
+    return this.personalKeyService.has(visitorId)
+      ? [...aliases, YoutubePersonalKeyService.alias]
+      : aliases;
   }
 
   private getConfiguredApiKeys(): Record<string, string> {
@@ -292,24 +320,40 @@ export class YoutubeService {
       });
     }
 
-    const isKeyRestrictionMismatch =
-      hasReason(
-        'ipRefererBlocked',
-        'API_KEY_HTTP_REFERRER_BLOCKED',
-        'API_KEY_IP_ADDRESS_BLOCKED',
-        'API_KEY_SERVICE_BLOCKED',
-      ) ||
+    const isHttpReferrerBlocked =
+      hasReason('ipRefererBlocked', 'API_KEY_HTTP_REFERRER_BLOCKED') ||
       normalizedMessage.includes('requests from referer') ||
-      normalizedMessage.includes('application restriction') ||
+      normalizedMessage.includes('http referrer');
+    const isIpAddressBlocked = hasReason('API_KEY_IP_ADDRESS_BLOCKED');
+    const isServiceBlocked =
+      hasReason('API_KEY_SERVICE_BLOCKED') ||
       normalizedMessage.includes('api key service restrictions');
+    const isApplicationRestrictionBlocked = normalizedMessage.includes(
+      'application restriction',
+    );
+    const isKeyRestrictionMismatch =
+      isHttpReferrerBlocked ||
+      isIpAddressBlocked ||
+      isServiceBlocked ||
+      isApplicationRestrictionBlocked;
     if (isKeyRestrictionMismatch) {
       this.logger.error(
-        'YouTube rejected the selected API key because its restrictions do not allow this backend request.',
+        `YouTube rejected the selected API key restriction; status ${status}; reason(s): ${
+          normalizedReasons.join(', ') || 'restriction mismatch'
+        }.`,
       );
+
+      const message = isHttpReferrerBlocked
+        ? 'This YouTube API key is restricted to browser referrers and cannot be used by the backend.'
+        : isIpAddressBlocked
+          ? 'This YouTube API key does not allow requests from the backend server IP address.'
+          : isServiceBlocked
+            ? 'This API key does not allow YouTube Data API v3. Update its API restrictions in Google Cloud Console.'
+            : 'Google rejected this API key because its application restrictions do not allow the backend request.';
+
       throw new ServiceUnavailableException({
         code: 'youtube_key_restricted',
-        message:
-          'The selected YouTube API key restrictions do not allow backend requests. Configure it as a server key.',
+        message,
       });
     }
 

--- a/src/modules/youtube/youtube.types.ts
+++ b/src/modules/youtube/youtube.types.ts
@@ -24,6 +24,19 @@ export interface YoutubeKeyAliasesResponse {
   defaultAlias: string;
 }
 
+export interface YoutubePersonalKeyRequest {
+  apiKey: string;
+}
+
+export interface YoutubePersonalKeyStatusResponse {
+  available: boolean;
+  alias: string;
+}
+
+export interface YoutubePersonalKeyDeleteResponse {
+  removed: boolean;
+}
+
 export interface YoutubeApiError {
   message?: string;
   status?: string;

--- a/src/search.gateway.spec.ts
+++ b/src/search.gateway.spec.ts
@@ -1,0 +1,66 @@
+import { Server, Socket } from 'socket.io';
+import { SearchGateway } from './search.gateway';
+
+describe('SearchGateway', () => {
+  const visitorId = '123e4567-e89b-42d3-a456-426614174000';
+  let gateway: SearchGateway;
+  let roomEmit: jest.Mock;
+  let toRoom: jest.Mock;
+
+  beforeEach(() => {
+    gateway = new SearchGateway();
+    roomEmit = jest.fn();
+    toRoom = jest.fn(() => ({ emit: roomEmit }));
+    gateway.server = { to: toRoom } as unknown as Server;
+  });
+
+  function createClient(authVisitorId = visitorId): Socket {
+    return {
+      id: 'socket-id',
+      handshake: {
+        auth: { visitorID: authVisitorId },
+        query: {},
+      },
+      join: jest.fn(),
+      disconnect: jest.fn(),
+    } as unknown as Socket;
+  }
+
+  it('joins a valid visitor room and emits only to that room', async () => {
+    const client = createClient();
+
+    gateway.handleConnection(client);
+    await gateway.onSearch(client, {
+      event: 'onSearch',
+      visitorID: visitorId,
+      data: { search: 'test' },
+    });
+
+    expect(client.join).toHaveBeenCalledWith(visitorId);
+    expect(toRoom).toHaveBeenCalledWith(visitorId);
+    expect(roomEmit).toHaveBeenCalledWith(
+      'onSearch',
+      expect.objectContaining({ visitorID: visitorId }),
+    );
+  });
+
+  it('rejects an event whose payload visitor ID does not match the socket', async () => {
+    const client = createClient();
+
+    await gateway.onSearch(client, {
+      event: 'onSearch',
+      visitorID: '123e4567-e89b-42d3-a456-426614174001',
+    });
+
+    expect(toRoom).not.toHaveBeenCalled();
+  });
+
+  it('disconnects sockets without a valid UUID visitor ID', () => {
+    const client = createClient('legacy123');
+
+    gateway.handleConnection(client);
+
+    expect(client.join).not.toHaveBeenCalled();
+    expect(client.disconnect).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/search.gateway.ts
+++ b/src/search.gateway.ts
@@ -30,25 +30,57 @@ export class SearchGateway implements OnGatewayConnection, OnGatewayDisconnect {
   private readonly shouldLogEvents = process.env.NODE_ENV !== 'production';
 
   private getVisitorID(client: Socket): string {
-    return (client.handshake.query.visitorID as string) || client.id;
+    const authVisitorId = client.handshake.auth?.visitorID;
+    const queryVisitorId = client.handshake.query.visitorID;
+    const visitorId =
+      typeof authVisitorId === 'string'
+        ? authVisitorId
+        : typeof queryVisitorId === 'string'
+          ? queryVisitorId
+          : '';
+    return this.isValidVisitorID(visitorId) ? visitorId : '';
   }
 
   private handleEvent(client: Socket, payload: EventPayload, eventName: string): void {
     const visitorID = this.getVisitorID(client);
+    if (!visitorID) {
+      client.disconnect(true);
+      return;
+    }
+
+    const payloadVisitorID = payload?.visitorID;
+    if (
+      typeof payloadVisitorID === 'string' &&
+      payloadVisitorID !== visitorID
+    ) {
+      this.logger.warn(`Rejected ${eventName} with a mismatched visitor ID.`);
+      return;
+    }
     if (this.shouldLogEvents) {
       this.logger.log(`🔄 Guest ${visitorID} handled ${eventName}`);
     }
-    this.server.emit(eventName, { ...payload, visitorID });
+    this.server.to(visitorID).emit(eventName, { ...payload, visitorID });
   }
 
   handleConnection(client: Socket): void {
     const visitorID = this.getVisitorID(client);
+    if (!visitorID) {
+      this.logger.warn('Rejected a WebSocket connection without a valid visitor ID.');
+      client.disconnect(true);
+      return;
+    }
     client.join(visitorID);
     // this.logger.log(`✅ Client connected: ${client.id} (Guest ID: ${visitorID})`);
   }
 
   handleDisconnect(client: Socket): void {
     this.logger.log(`❌ Client disconnected: ${client.id}`);
+  }
+
+  private isValidVisitorID(visitorID: string): boolean {
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      visitorID.trim(),
+    );
   }
 
   // Request events (client to server)


### PR DESCRIPTION
feat(youtube): add backend personal keys and improve remote sync

- move YouTube key usage to the backend
- add visitor-bound personal API key management
- allow personal key setup from main and remote
- sync active key, theme, menu mode, and session state
- improve Google API error classification
- filter non-embeddable and non-syndicated videos
- improve remote queue viewport layout
- add secure visitor ID fallback for LAN HTTP