### PR TITLE
feat(youtube): cache searches and lazy-load suggestions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,8 @@ YOUTUBE_DEFAULT_API_KEY_ALIAS=primary
 # remain until explicitly removed or until the backend process restarts.
 YOUTUBE_PERSONAL_KEYS_ENABLED=true
 YOUTUBE_PERSONAL_KEY_MAX_SESSIONS=200
+YOUTUBE_SEARCH_CACHE_TTL_MS=21600000
+YOUTUBE_SEARCH_CACHE_MAX_ENTRIES=500
 
 # Optional fallback for deployments that use only one key.
 YOUTUBE_API_KEY=

--- a/src/modules/youtube/youtube-search-cache.service.spec.ts
+++ b/src/modules/youtube/youtube-search-cache.service.spec.ts
@@ -1,0 +1,91 @@
+import { ConfigService } from '@nestjs/config';
+import { YoutubeSearchResponse } from './youtube.types';
+import { YoutubeSearchCacheService } from './youtube-search-cache.service';
+
+describe('YoutubeSearchCacheService', () => {
+  const emptyResponse: YoutubeSearchResponse = { items: [] };
+
+  function createCache(config: Record<string, string> = {}) {
+    const configService = {
+      get: jest.fn((name: string) => config[name]),
+    } as unknown as ConfigService;
+    return new YoutubeSearchCacheService(configService);
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('normalizes keywords and caches successful responses', async () => {
+    const cache = createCache();
+    const factory = jest.fn().mockResolvedValue(emptyResponse);
+
+    await cache.getOrCreate('  Disco   Karaoke  ', factory);
+    await cache.getOrCreate('disco karaoke', factory);
+
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('deduplicates simultaneous requests for the same keyword', async () => {
+    const cache = createCache();
+    let resolveRequest: ((response: YoutubeSearchResponse) => void) | undefined;
+    const pendingResponse = new Promise<YoutubeSearchResponse>((resolve) => {
+      resolveRequest = resolve;
+    });
+    const factory = jest.fn(() => pendingResponse);
+
+    const firstRequest = cache.getOrCreate('OPM Karaoke', factory);
+    const secondRequest = cache.getOrCreate(' opm  karaoke ', factory);
+    resolveRequest?.(emptyResponse);
+
+    await expect(Promise.all([firstRequest, secondRequest])).resolves.toEqual([
+      emptyResponse,
+      emptyResponse,
+    ]);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache failed requests', async () => {
+    const cache = createCache();
+    const factory = jest
+      .fn<Promise<YoutubeSearchResponse>, []>()
+      .mockRejectedValueOnce(new Error('YouTube unavailable'))
+      .mockResolvedValueOnce(emptyResponse);
+
+    await expect(cache.getOrCreate('failed search', factory)).rejects.toThrow(
+      'YouTube unavailable',
+    );
+    await expect(cache.getOrCreate('failed search', factory)).resolves.toBe(
+      emptyResponse,
+    );
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it('evicts the least recently used entry at the configured limit', async () => {
+    const cache = createCache({ YOUTUBE_SEARCH_CACHE_MAX_ENTRIES: '2' });
+    const factory = jest.fn().mockResolvedValue(emptyResponse);
+
+    await cache.getOrCreate('first', factory);
+    await cache.getOrCreate('second', factory);
+    await cache.getOrCreate('first', factory);
+    await cache.getOrCreate('third', factory);
+    await cache.getOrCreate('second', factory);
+
+    expect(factory).toHaveBeenCalledTimes(4);
+  });
+
+  it('expires entries after the configured TTL', async () => {
+    let now = 1_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+    const cache = createCache({ YOUTUBE_SEARCH_CACHE_TTL_MS: '1000' });
+    const factory = jest.fn().mockResolvedValue(emptyResponse);
+
+    await cache.getOrCreate('timed', factory);
+    now = 1_999;
+    await cache.getOrCreate('timed', factory);
+    now = 2_000;
+    await cache.getOrCreate('timed', factory);
+
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/modules/youtube/youtube-search-cache.service.ts
+++ b/src/modules/youtube/youtube-search-cache.service.ts
@@ -1,0 +1,115 @@
+import { ConfigService } from '@nestjs/config';
+import { Injectable, Logger } from '@nestjs/common';
+import { YoutubeSearchResponse } from './youtube.types';
+
+interface YoutubeSearchCacheEntry {
+  response: YoutubeSearchResponse;
+  expiresAt: number;
+}
+
+@Injectable()
+export class YoutubeSearchCacheService {
+  private readonly logger = new Logger(YoutubeSearchCacheService.name);
+  private readonly cache = new Map<string, YoutubeSearchCacheEntry>();
+  private readonly inFlight = new Map<string, Promise<YoutubeSearchResponse>>();
+  private readonly ttlMs: number;
+  private readonly maximumEntries: number;
+
+  constructor(private readonly configService: ConfigService) {
+    this.ttlMs = this.getPositiveInteger(
+      'YOUTUBE_SEARCH_CACHE_TTL_MS',
+      6 * 60 * 60 * 1000,
+    );
+    this.maximumEntries = this.getPositiveInteger(
+      'YOUTUBE_SEARCH_CACHE_MAX_ENTRIES',
+      500,
+    );
+  }
+
+  getOrCreate(
+    keyword: string,
+    factory: () => Promise<YoutubeSearchResponse>,
+  ): Promise<YoutubeSearchResponse> {
+    const cacheKey = this.normalizeKeyword(keyword);
+    const cachedResponse = this.get(cacheKey);
+    if (cachedResponse) {
+      this.logger.debug(`YouTube search cache hit for "${cacheKey}".`);
+      return Promise.resolve(cachedResponse);
+    }
+
+    const pendingRequest = this.inFlight.get(cacheKey);
+    if (pendingRequest) {
+      this.logger.debug(`Joined in-flight YouTube search for "${cacheKey}".`);
+      return pendingRequest;
+    }
+
+    const request = factory()
+      .then((response) => {
+        this.set(cacheKey, response);
+        return response;
+      })
+      .finally(() => {
+        this.inFlight.delete(cacheKey);
+      });
+
+    this.inFlight.set(cacheKey, request);
+    return request;
+  }
+
+  private get(cacheKey: string): YoutubeSearchResponse | undefined {
+    const entry = this.cache.get(cacheKey);
+    if (!entry) {
+      return undefined;
+    }
+
+    if (entry.expiresAt <= Date.now()) {
+      this.cache.delete(cacheKey);
+      return undefined;
+    }
+
+    this.cache.delete(cacheKey);
+    this.cache.set(cacheKey, entry);
+    return entry.response;
+  }
+
+  private set(cacheKey: string, response: YoutubeSearchResponse): void {
+    this.removeExpiredEntries();
+    this.cache.delete(cacheKey);
+
+    while (this.cache.size >= this.maximumEntries) {
+      const leastRecentlyUsedKey = this.cache.keys().next().value as
+        | string
+        | undefined;
+      if (!leastRecentlyUsedKey) {
+        break;
+      }
+      this.cache.delete(leastRecentlyUsedKey);
+    }
+
+    this.cache.set(cacheKey, {
+      response,
+      expiresAt: Date.now() + this.ttlMs,
+    });
+  }
+
+  private removeExpiredEntries(): void {
+    const now = Date.now();
+    for (const [cacheKey, entry] of this.cache.entries()) {
+      if (entry.expiresAt <= now) {
+        this.cache.delete(cacheKey);
+      }
+    }
+  }
+
+  private normalizeKeyword(keyword: string): string {
+    return keyword.trim().replace(/\s+/g, ' ').toLowerCase();
+  }
+
+  private getPositiveInteger(name: string, fallback: number): number {
+    const configuredValue = this.configService.get<string | number>(name);
+    const parsedValue = Number(configuredValue);
+    return Number.isInteger(parsedValue) && parsedValue > 0
+      ? parsedValue
+      : fallback;
+  }
+}

--- a/src/modules/youtube/youtube.module.ts
+++ b/src/modules/youtube/youtube.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { YoutubeController } from './youtube.controller';
 import { YoutubePersonalKeyService } from './youtube-personal-key.service';
 import { YoutubeRateLimiterService } from './youtube-rate-limiter.service';
+import { YoutubeSearchCacheService } from './youtube-search-cache.service';
 import { YoutubeService } from './youtube.service';
 
 @Module({
@@ -10,6 +11,7 @@ import { YoutubeService } from './youtube.service';
     YoutubeService,
     YoutubePersonalKeyService,
     YoutubeRateLimiterService,
+    YoutubeSearchCacheService,
   ],
 })
 export class YoutubeModule {}

--- a/src/modules/youtube/youtube.service.spec.ts
+++ b/src/modules/youtube/youtube.service.spec.ts
@@ -1,6 +1,7 @@
 import { ServiceUnavailableException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { YoutubePersonalKeyService } from './youtube-personal-key.service';
+import { YoutubeSearchCacheService } from './youtube-search-cache.service';
 import { YoutubeService } from './youtube.service';
 
 describe('YoutubeService', () => {
@@ -8,6 +9,7 @@ describe('YoutubeService', () => {
   const backupApiKey = 'server-only-backup-test-key';
   let service: YoutubeService;
   let personalKeyService: YoutubePersonalKeyService;
+  let searchCacheService: YoutubeSearchCacheService;
   let fetchMock: jest.SpiedFunction<typeof fetch>;
 
   beforeEach(() => {
@@ -22,7 +24,12 @@ describe('YoutubeService', () => {
       get: jest.fn((name: string) => configValues[name]),
     } as unknown as ConfigService;
     personalKeyService = new YoutubePersonalKeyService(configService);
-    service = new YoutubeService(configService, personalKeyService);
+    searchCacheService = new YoutubeSearchCacheService(configService);
+    service = new YoutubeService(
+      configService,
+      personalKeyService,
+      searchCacheService,
+    );
     fetchMock = jest.spyOn(global, 'fetch');
   });
 
@@ -69,6 +76,20 @@ describe('YoutubeService', () => {
     });
     expect(JSON.stringify(service.getKeyAliases())).not.toContain(apiKey);
     expect(JSON.stringify(service.getKeyAliases())).not.toContain(backupApiKey);
+  });
+
+  it('reuses a cached response for equivalent normalized searches', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ items: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await service.search('  Disco   Karaoke  ');
+    await service.search('disco karaoke');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('uses the manually selected key alias', async () => {
@@ -232,7 +253,12 @@ describe('YoutubeService', () => {
       get: jest.fn().mockReturnValue(undefined),
     } as unknown as ConfigService;
     personalKeyService = new YoutubePersonalKeyService(configService);
-    service = new YoutubeService(configService, personalKeyService);
+    searchCacheService = new YoutubeSearchCacheService(configService);
+    service = new YoutubeService(
+      configService,
+      personalKeyService,
+      searchCacheService,
+    );
 
     await expect(service.search('test')).rejects.toBeInstanceOf(
       ServiceUnavailableException,

--- a/src/modules/youtube/youtube.service.ts
+++ b/src/modules/youtube/youtube.service.ts
@@ -16,6 +16,7 @@ import {
   YoutubeSearchResponse,
 } from './youtube.types';
 import { YoutubePersonalKeyService } from './youtube-personal-key.service';
+import { YoutubeSearchCacheService } from './youtube-search-cache.service';
 
 @Injectable()
 export class YoutubeService {
@@ -27,6 +28,7 @@ export class YoutubeService {
   constructor(
     private readonly configService: ConfigService,
     private readonly personalKeyService: YoutubePersonalKeyService,
+    private readonly searchCacheService: YoutubeSearchCacheService,
   ) {}
 
   getKeyAliases(visitorId?: string): YoutubeKeyAliasesResponse {
@@ -69,6 +71,16 @@ export class YoutubeService {
     const effectiveQuery = normalizedQuery.toLowerCase().includes('karaoke')
       ? normalizedQuery
       : `${normalizedQuery} Karaoke`;
+
+    return this.searchCacheService.getOrCreate(effectiveQuery, () =>
+      this.fetchSearch(effectiveQuery, apiKey),
+    );
+  }
+
+  private async fetchSearch(
+    effectiveQuery: string,
+    apiKey: string,
+  ): Promise<YoutubeSearchResponse> {
     const params = new URLSearchParams({
       part: 'snippet',
       q: effectiveQuery,


### PR DESCRIPTION
feat(youtube): cache searches and lazy-load suggestions

- add normalized six-hour backend search cache
- limit cache size with LRU eviction
- deduplicate simultaneous searches for the same keyword
- cache successful YouTube responses only
- lazy-load suggested songs when opening search
- cancel pending suggestions when manual search starts
- add cache configuration and unit tests